### PR TITLE
chore: initialize project structure

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to Agent Stream
+
+We love your input! We want to make contributing to Agent Stream as easy and transparent as possible, whether it's:
+
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
+- Becoming a maintainer
+
+## Development Process
+We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
+
+## Pull Requests
+1. Fork the repo and create your branch from `main`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. Issue that pull request!
+
+## Report bugs using GitHub's [issue tracker](https://github.com/yourusername/agentstream/issues)
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/yourusername/agentstream/issues/new); it's that easy!
+
+## Write bug reports with detail, background, and sample code
+
+**Great Bug Reports** tend to have:
+
+- A quick summary and/or background
+- Steps to reproduce
+  - Be specific!
+  - Give sample code if you can.
+- What you expected would happen
+- What actually happens
+- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Motivation
+Please describe the motivation behind this change. What problem does it solve? What is the expected outcome?
+
+## Modification
+Please describe the changes you've made to address the motivation above. Include:
+- What changes were made
+- Why these changes were chosen
+- Any technical details that reviewers should know

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# agentstream
+# Agent Stream
+
+Agent Stream is a powerful platform for managing and orchestrating AI agents.
+
+## Project Structure
+
+```
+project-root/
+│
+├── .github/            # Github / CI
+│
+├── operator/           # Agent Stream Operator code
+│
+├── web/               # Frontend code
+│
+├── sdk/               # SDK directory
+│
+└── README.md
+```
+
+## Contributing
+
+Please read [CONTRIBUTING.md](.github/CONTRIBUTING.md) for details on our code of conduct and the process for submitting pull requests.

--- a/operator/.placeholder
+++ b/operator/.placeholder
@@ -1,0 +1,1 @@
+This directory contains the Agent Stream Operator code. 

--- a/sdk/.placeholder
+++ b/sdk/.placeholder
@@ -1,0 +1,1 @@
+This directory contains the Agent Stream SDK code. 

--- a/web/.placeholder
+++ b/web/.placeholder
@@ -1,0 +1,1 @@
+This directory contains the frontend code for Agent Stream. 


### PR DESCRIPTION
## Motivation
Initialize the basic project structure for Agent Stream, including:
- GitHub templates and guidelines
- Main project directories (operator, web, sdk)
- Basic documentation

## Modification
- Created `.github` directory with templates and guidelines
  - Added PR template
  - Added contributing guidelines
- Created main project directories with placeholders
  - `operator/` for Agent Stream Operator code
  - `web/` for frontend code
  - `sdk/` for SDK code
- Edit README.md with project structure and setup instructions