### PR TITLE
feat: add authentication support to PulsarRPCManager

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -38,9 +38,16 @@ class AgentFunction(FSModule):
 
     def init(self, context: FSContext):
         self.config = AgentConfig.model_validate(context.get_configs())
+        
+        # Extract auth parameters from PulsarConfig if available
+        auth_plugin = self.config.pulsarRpc.authPlugin
+        auth_params = self.config.pulsarRpc.authParams
+        
         self.rpc_manager = PulsarRPCManager(
             service_url=self.config.pulsarRpc.serviceUrl,
             response_topic=self.config.responseSource.pulsar.topic,
+            auth_plugin=auth_plugin,
+            auth_params=auth_params,
         )
         self.session_service = InMemorySessionService()
         self.runner = None

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -9,12 +9,12 @@ config:
                     A tool that returns the current time.
                 requestSource: request_current_time
     model:
-        googleApiKey: AIzaSyAk-iIAZOxUjs9MdeEtQ2AFScz8TG6BnU4
+        googleApiKey: <API-KEY>
         model: gemini-2.0-flash
     pulsarRpc:
         authParams: ""
         authPlugin: ""
-        serviceUrl: pulsar://192.168.31.80:6650
+        serviceUrl: pulsar://localhost:6650
     responseSource:
         pulsar:
             topic: agent_response
@@ -25,7 +25,7 @@ package: agent
 pulsar:
     authParams: ""
     authPlugin: ""
-    serviceUrl: pulsar://192.168.31.80:6650
+    serviceUrl: pulsar://localhost:6650
 requestSource:
     pulsar:
         topic: request_agent


### PR DESCRIPTION

### Motivation

This change adds authentication support to the PulsarRPCManager to enable secure connections to Pulsar brokers. Previously, the PulsarRPCManager only supported unauthenticated connections, which limited its use in production environments where authentication is required.

### Modifications

- **Enhanced PulsarRPCManager constructor**: Added optional `auth_plugin` and `auth_params` parameters to support different authentication methods (TLS, token, OAuth2, etc.)
- **Authentication implementation**: Added logic to create Pulsar authentication objects when credentials are provided, with proper error handling and logging
- **Updated Agent initialization**: Modified the AgentFunction to extract and pass authentication parameters from the PulsarConfig to the PulsarRPCManager
- **Improved logging**: Added informative log messages to indicate whether authentication is being used or not

The changes maintain backward compatibility - if no authentication parameters are provided, the manager will work as before without authentication.