### PR TITLE
feat: add configurable agent package and module support

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -68,6 +68,8 @@ func main() {
 	var pulsarServiceUrl string
 	var pulsarAuthPlugin string
 	var pulsarAuthParams string
+	var agentPackage string
+	var agentModule string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -90,6 +92,8 @@ func main() {
 	flag.StringVar(&pulsarServiceUrl, "pulsar-service-url", os.Getenv("PULSAR_SERVICE_URL"), "Pulsar service URL")
 	flag.StringVar(&pulsarAuthPlugin, "pulsar-auth-plugin", os.Getenv("PULSAR_AUTH_PLUGIN"), "Pulsar auth plugin")
 	flag.StringVar(&pulsarAuthParams, "pulsar-auth-params", os.Getenv("PULSAR_AUTH_PARAMS"), "Pulsar auth params")
+	flag.StringVar(&agentPackage, "agent-package", os.Getenv("AGENT_PACKAGE"), "Agent package name")
+	flag.StringVar(&agentModule, "agent-module", os.Getenv("AGENT_MODULE"), "Agent module name")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -100,6 +104,8 @@ func main() {
 		PulsarServiceURL: pulsarServiceUrl,
 		PulsarAuthPlugin: pulsarAuthPlugin,
 		PulsarAuthParams: pulsarAuthParams,
+		AgentPackage:     agentPackage,
+		AgentModule:      agentModule,
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))

--- a/operator/deploy/chart/templates/manager/manager.yaml
+++ b/operator/deploy/chart/templates/manager/manager.yaml
@@ -31,6 +31,12 @@ spec:
             {{- range .Values.controllerManager.container.args }}
             - {{ . }}
             {{- end }}
+            {{- if .Values.agent.package }}
+            - --agent-package={{ .Values.agent.package }}
+            {{- end }}
+            {{- if .Values.agent.module }}
+            - --agent-module={{ .Values.agent.module }}
+            {{- end }}
           command:
             - /manager
           image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag }}
@@ -46,6 +52,14 @@ spec:
             {{- if .Values.pulsar.authParams }}
             - name: PULSAR_AUTH_PARAMS
               value: {{ .Values.pulsar.authParams }}
+            {{- end }}
+            {{- if .Values.agent.package }}
+            - name: AGENT_PACKAGE
+              value: {{ .Values.agent.package }}
+            {{- end }}
+            {{- if .Values.agent.module }}
+            - name: AGENT_MODULE
+              value: {{ .Values.agent.module }}
             {{- end }}
             {{- if .Values.controllerManager.container.env }}
             {{- range $key, $value := .Values.controllerManager.container.env }}

--- a/operator/deploy/chart/values.yaml
+++ b/operator/deploy/chart/values.yaml
@@ -12,6 +12,14 @@ pulsar:
   # Authentication parameters for Pulsar (e.g., "tlsCertFile:/path/to/cert.pem,tlsKeyFile:/path/to/key.pem")
   authParams: ""
 
+# [AGENT]: Agent configuration options
+agent:
+  # Package reference in format "namespace.name" or "name" (defaults to "default" namespace)
+  # Default value uses the Helm chart's namespace
+  package: "{{ .Release.Namespace }}.agent"
+  # Module name within the package
+  module: "agent"
+
 # [MANAGER]: Manager Deployment Configurations
 controllerManager:
   replicas: 1

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -5,8 +5,12 @@ go 1.23.0
 godebug default=go1.23
 
 require (
+	github.com/FunctionStream/function-stream/operator v0.0.0-20250720145025-985bd76f2566
+	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
+	github.com/stretchr/testify v1.9.0
+	k8s.io/apiextensions-apiserver v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
 	sigs.k8s.io/controller-runtime v0.20.4
@@ -14,7 +18,6 @@ require (
 
 require (
 	cel.dev/expr v0.18.0 // indirect
-	github.com/FunctionStream/function-stream/operator v0.0.0-20250622101053-929ca3717ef1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -42,7 +45,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -52,6 +54,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
@@ -88,7 +91,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.32.1 // indirect
-	k8s.io/apiextensions-apiserver v0.32.1 // indirect
 	k8s.io/apiserver v0.32.1 // indirect
 	k8s.io/component-base v0.32.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -1,7 +1,7 @@
 cel.dev/expr v0.18.0 h1:CJ6drgk+Hf96lkLikr4rFf19WrU0BOWEihyZnI2TAzo=
 cel.dev/expr v0.18.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
-github.com/FunctionStream/function-stream/operator v0.0.0-20250622101053-929ca3717ef1 h1:YJ0a9NJhMtC1Xcv0bfcIZ5G9IwQWGa9GwpslavT0KaY=
-github.com/FunctionStream/function-stream/operator v0.0.0-20250622101053-929ca3717ef1/go.mod h1:i3exKXYIuJvGgtGa7wn0O9ULD8lxlkBAbIfOgBqzHOQ=
+github.com/FunctionStream/function-stream/operator v0.0.0-20250720145025-985bd76f2566 h1:O6WOHkwEo42wIhXjNCrvuASFpqJ6R7HkgqPH9kJn/N0=
+github.com/FunctionStream/function-stream/operator v0.0.0-20250720145025-985bd76f2566/go.mod h1:QciXuUhHeGeqfWch6imvth3HpJJxKLVjG/6CQuWXBmk=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 h1:4daAzAu0S6Vi7/lbWECcX0j45yZReDZ56BQsrVBOEEY=

--- a/operator/internal/controller/agent_controller_test.go
+++ b/operator/internal/controller/agent_controller_test.go
@@ -563,5 +563,302 @@ var _ = Describe("Agent Controller", func() {
 			Expect(agentCtx.PostProcess).NotTo(BeNil())
 			Expect(agentCtx.PostProcess.Jsonnet).To(Equal("test-jsonnet"))
 		})
+
+		It("Should handle agent with default package configuration", func() {
+			By("Creating an agent with default package configuration")
+			agent := &asv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-agent-default-pkg",
+					Namespace: "default",
+				},
+				Spec: asv1alpha1.AgentSpec{
+					DisplayName: "Test Agent Default Package",
+					Description: "A test agent with default package configuration",
+					Instruction: "Test instruction",
+					Model: asv1alpha1.ModelConfig{
+						Model: "gpt-4",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+
+			By("Reconciling with default package configuration")
+			controllerReconciler := &AgentReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Config: Config{
+					PulsarServiceURL: "pulsar://localhost:6650",
+					PulsarAuthPlugin: "",
+					PulsarAuthParams: "",
+					AgentPackage:     "",
+					AgentModule:      "",
+				},
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      agent.Name,
+					Namespace: agent.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify that the Function was created with default package configuration
+			function := &fsv1alpha1.Function{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      agent.Name,
+				Namespace: agent.Namespace,
+			}, function)).To(Succeed())
+			Expect(function.Spec.PackageRef.Name).To(Equal("agent"))
+			Expect(function.Spec.PackageRef.Namespace).To(Equal("default"))
+			Expect(function.Spec.Module).To(Equal("agent"))
+
+			// Clean up
+			Expect(k8sClient.Delete(ctx, agent)).To(Succeed())
+		})
+
+		It("Should handle agent with custom package configuration", func() {
+			By("Creating an agent with custom package configuration")
+			agent := &asv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-agent-custom-pkg",
+					Namespace: "default",
+				},
+				Spec: asv1alpha1.AgentSpec{
+					DisplayName: "Test Agent Custom Package",
+					Description: "A test agent with custom package configuration",
+					Instruction: "Test instruction",
+					Model: asv1alpha1.ModelConfig{
+						Model: "gpt-4",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+
+			By("Reconciling with custom package configuration")
+			controllerReconciler := &AgentReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Config: Config{
+					PulsarServiceURL: "pulsar://localhost:6650",
+					PulsarAuthPlugin: "",
+					PulsarAuthParams: "",
+					AgentPackage:     "my-namespace.my-agent-package",
+					AgentModule:      "custom-module",
+				},
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      agent.Name,
+					Namespace: agent.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify that the Function was created with custom package configuration
+			function := &fsv1alpha1.Function{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      agent.Name,
+				Namespace: agent.Namespace,
+			}, function)).To(Succeed())
+			Expect(function.Spec.PackageRef.Name).To(Equal("my-agent-package"))
+			Expect(function.Spec.PackageRef.Namespace).To(Equal("my-namespace"))
+			Expect(function.Spec.Module).To(Equal("custom-module"))
+
+			// Clean up
+			Expect(k8sClient.Delete(ctx, agent)).To(Succeed())
+		})
+
+		It("Should handle agent with package name only configuration", func() {
+			By("Creating an agent with package name only configuration")
+			agent := &asv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-agent-pkg-name-only",
+					Namespace: "default",
+				},
+				Spec: asv1alpha1.AgentSpec{
+					DisplayName: "Test Agent Package Name Only",
+					Description: "A test agent with package name only configuration",
+					Instruction: "Test instruction",
+					Model: asv1alpha1.ModelConfig{
+						Model: "gpt-4",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+
+			By("Reconciling with package name only configuration")
+			controllerReconciler := &AgentReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Config: Config{
+					PulsarServiceURL: "pulsar://localhost:6650",
+					PulsarAuthPlugin: "",
+					PulsarAuthParams: "",
+					AgentPackage:     "my-agent-package",
+					AgentModule:      "agent",
+				},
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      agent.Name,
+					Namespace: agent.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify that the Function was created with package name only configuration
+			function := &fsv1alpha1.Function{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      agent.Name,
+				Namespace: agent.Namespace,
+			}, function)).To(Succeed())
+			Expect(function.Spec.PackageRef.Name).To(Equal("my-agent-package"))
+			Expect(function.Spec.PackageRef.Namespace).To(Equal("default"))
+			Expect(function.Spec.Module).To(Equal("agent"))
+
+			// Clean up
+			Expect(k8sClient.Delete(ctx, agent)).To(Succeed())
+		})
+
+		It("Should handle agent with empty module configuration", func() {
+			By("Creating an agent with empty module configuration")
+			agent := &asv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-agent-empty-module",
+					Namespace: "default",
+				},
+				Spec: asv1alpha1.AgentSpec{
+					DisplayName: "Test Agent Empty Module",
+					Description: "A test agent with empty module configuration",
+					Instruction: "Test instruction",
+					Model: asv1alpha1.ModelConfig{
+						Model: "gpt-4",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+
+			By("Reconciling with empty module configuration")
+			controllerReconciler := &AgentReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Config: Config{
+					PulsarServiceURL: "pulsar://localhost:6650",
+					PulsarAuthPlugin: "",
+					PulsarAuthParams: "",
+					AgentPackage:     "my-namespace.my-agent-package",
+					AgentModule:      "", // Empty module should default to "agent"
+				},
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      agent.Name,
+					Namespace: agent.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify that the Function was created with default module
+			function := &fsv1alpha1.Function{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      agent.Name,
+				Namespace: agent.Namespace,
+			}, function)).To(Succeed())
+			Expect(function.Spec.PackageRef.Name).To(Equal("my-agent-package"))
+			Expect(function.Spec.PackageRef.Namespace).To(Equal("my-namespace"))
+			Expect(function.Spec.Module).To(Equal("agent")) // Should default to "agent"
+
+			// Clean up
+			Expect(k8sClient.Delete(ctx, agent)).To(Succeed())
+		})
+	})
+
+	Context("Package reference parsing", func() {
+		It("Should parse package references correctly", func() {
+			// Test the parsePackageRef function directly
+			ns, name := parsePackageRef("")
+			Expect(ns).To(Equal("default"))
+			Expect(name).To(Equal("agent"))
+
+			ns, name = parsePackageRef("my-package")
+			Expect(ns).To(Equal("default"))
+			Expect(name).To(Equal("my-package"))
+
+			ns, name = parsePackageRef("my-namespace.my-package")
+			Expect(ns).To(Equal("my-namespace"))
+			Expect(name).To(Equal("my-package"))
+
+			ns, name = parsePackageRef("functionstream.agent-package")
+			Expect(ns).To(Equal("functionstream"))
+			Expect(name).To(Equal("agent-package"))
+		})
+	})
+
+	Context("Configuration integration", func() {
+		It("Should integrate package and module configuration correctly", func() {
+			agent := &asv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-agent-integration",
+					Namespace: "default",
+				},
+				Spec: asv1alpha1.AgentSpec{
+					DisplayName: "Test Agent Integration",
+					Description: "A test agent for integration testing",
+					Instruction: "Test instruction",
+					Model: asv1alpha1.ModelConfig{
+						Model: "gpt-4",
+					},
+					ResponseSource: &fsv1alpha1.SourceSpec{
+						Pulsar: &fsv1alpha1.PulsarSourceSpec{
+							Topic: "response-topic",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+
+			controllerReconciler := &AgentReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Config: Config{
+					PulsarServiceURL: "pulsar://localhost:6650",
+					PulsarAuthPlugin: "",
+					PulsarAuthParams: "",
+					AgentPackage:     "test-namespace.test-package",
+					AgentModule:      "test-module",
+				},
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      agent.Name,
+					Namespace: agent.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the complete integration
+			function := &fsv1alpha1.Function{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      agent.Name,
+				Namespace: agent.Namespace,
+			}, function)).To(Succeed())
+
+			// Check package reference
+			Expect(function.Spec.PackageRef.Name).To(Equal("test-package"))
+			Expect(function.Spec.PackageRef.Namespace).To(Equal("test-namespace"))
+			Expect(function.Spec.Module).To(Equal("test-module"))
+
+			// Check other fields are preserved
+			Expect(function.Spec.DisplayName).To(Equal("Test Agent Integration"))
+			Expect(function.Spec.Description).To(Equal("A test agent for integration testing"))
+
+			// Clean up
+			Expect(k8sClient.Delete(ctx, agent)).To(Succeed())
+		})
 	})
 })

--- a/operator/scripts/fs.yaml
+++ b/operator/scripts/fs.yaml
@@ -80,9 +80,18 @@ spec:
                 module:
                   description: Module name
                   type: string
-                package:
-                  description: Package name
-                  type: string
+                packageRef:
+                  description: Package reference
+                  properties:
+                    name:
+                      description: Name of the Package resource
+                      type: string
+                    namespace:
+                      description: Namespace of the Package resource
+                      type: string
+                  required:
+                    - name
+                  type: object
                 requestSource:
                   description: Request source
                   properties:
@@ -129,7 +138,7 @@ spec:
                   type: string
               required:
                 - module
-                - package
+                - packageRef
               type: object
             status:
               description: FunctionStatus defines the observed state of Function


### PR DESCRIPTION
### Motivation

The current implementation hardcodes the agent package name and module name, which limits flexibility in deployment configurations. This change introduces configurable agent package and module support to allow operators to specify custom package references and module names through environment variables and Helm chart values.

### Modifications

- **Added configurable agent package and module support**: Introduced new command-line flags `--agent-package` and `--agent-module` in the operator's main.go to allow runtime configuration of agent package and module names.

- **Enhanced Helm chart configuration**: Updated the Helm chart templates to support configurable agent package and module values through the `values.yaml` file, with proper environment variable injection.

- **Updated agent controller logic**: Modified the agent controller to use the new configurable package and module settings instead of hardcoded values, including:
  - Added `parsePackageRef` function to handle package reference parsing in format "namespace.name" or "name"
  - Updated Function creation logic to use `PackageRef` instead of hardcoded package name
  - Enhanced package lookup logic to support cross-namespace package references

- **Comprehensive test coverage**: Added extensive test cases to verify:
  - Default package configuration behavior
  - Custom package and module configuration
  - Package name-only configuration
  - Empty module configuration handling
  - Package reference parsing functionality
  - Complete integration scenarios

- **Updated dependencies**: Updated the FunctionStream operator dependency to the latest version and added necessary Go dependencies for enhanced functionality.

- **Schema updates**: Updated the FunctionStream CRD schema to use the new `packageRef` structure instead of the simple `package` field.

These changes provide operators with the flexibility to deploy agents with custom package configurations while maintaining backward compatibility through sensible defaults.